### PR TITLE
network-4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,27 @@
+## 2022-07-08
+
+### Added
+
+- Added `RemoteSignal:wait`.
+
+### Changed
+
+- Removed `RemoteSignal:disonnectAll` and `ClientRemoteSignal:disonnectAll`.
+- Removed `RemoteSignal:connectOnce` and `ClientRemoteSignal:connectOnce`.
+- Fix bug with `ClientRemoteSignal:connect` and `ClientRemoteSignal:wait` not receiving the dispatched events properly in some edge cases.
+- `RemoteSignal:connect` and `ClientRemoteSignal:connect` now return an `RBXScriptConnectionObject`. 
+- Internal code refactor and improvements.
+- Documentation improvements.
+
 ## 2022-07-07
 
 ### Added
 
-- Added `ReemoteSignal.fireAllClientsExcept`.
+- Added `RemoteSignal:fireAllClientsExcept`.
 
 ### Changed
 
-- Change `RemoteSignal.fireForClients` to `RemoteSignal.fireClients`.
+- Change `RemoteSignal:fireForClients` to `RemoteSignal:fireClients`.
 - Internal code refactor for `network`.
 - Documentation improvements for `network`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 | -- | -- | -- |
 | [Property](https://bubshayz.github.io/libraries/api/Property) | `Property = "bubshayz/property@1.1.2` | `shared` |
 | [Queue](https://bubshayz.github.io/libraries/api/Queue) | `Queue = "bubshayz/queue@1.1.3"` | `shared` |
-| [network](https://bubshayz.github.io/libraries/api/Network) | `Network = "bubshayz/network@3.1.0"` | `shared` |
+| [network](https://bubshayz.github.io/libraries/api/Network) | `Network = "bubshayz/network@4.0.0"` | `shared` |
 | [windLines](https://bubshayz.github.io/libraries/api/windLines) | `windLines = "bubshayz/windlines@1.2.2"` | `shared` |
 | [matrixUtil](https://bubshayz.github.io/libraries/api/matrixUtil) | `matrixUtil = "bubshayz/matrixutil@1.0.8"` | `shared` |
 | [instanceUtil](https://bubshayz.github.io/libraries/api/InstanceUtil) | `InstanceUtil = "bubshayz/instanceutil@1.1.0"` | `shared` |

--- a/src/network/Server/init.lua
+++ b/src/network/Server/init.lua
@@ -209,7 +209,7 @@
 local packages = script.Parent.Parent
 local utilities = script.Parent.utilities
 
-local SharedConstants = require(script.Parent.SharedConstants)
+local sharedEnums = require(script.Parent.sharedEnums)
 local RemoteSignal = require(script.RemoteSignal)
 local RemoteProperty = require(script.RemoteProperty)
 local tableUtil = require(utilities.tableUtil)
@@ -267,7 +267,7 @@ function NetworkServer.new(name: string, middleware: Middleware?): NetworkServer
 	assert(t.string(name))
 	assert(t.optional(t.table)(middleware))
 
-	if middleware then
+	if middleware ~= nil then
 		assert(MiddlewareInterface(middleware))
 	end
 
@@ -458,7 +458,7 @@ end
 function NetworkServer.__index:_setupNetworkFolder()
 	local networkFolder = self._janitor:Add(Instance.new("Folder"))
 	networkFolder.Name = self._name
-	networkFolder:SetAttribute(SharedConstants.attribute.networkFolder, true)
+	networkFolder:SetAttribute(sharedEnums.Attribute.networkFolder, true)
 	self._networkFolder = networkFolder
 end
 

--- a/src/network/client/init.lua
+++ b/src/network/client/init.lua
@@ -20,7 +20,7 @@
 local packages = script.Parent.Parent
 
 local Promise = require(packages.Promise)
-local SharedConstants = require(script.Parent.SharedConstants)
+local sharedEnums = require(script.Parent.sharedEnums)
 
 local networkClient = {
 	ClientRemoteProperty = require(script.ClientRemoteProperty),
@@ -31,10 +31,10 @@ local function getAbstractOfNetworkFolder(networkFolder): { [string]: any }
 	local abstract = {}
 
 	for _, descendant in networkFolder:GetChildren() do
-		if descendant:GetAttribute(SharedConstants.attribute.boundToRemoteSignal) then
+		if descendant:GetAttribute(sharedEnums.Attribute.boundToRemoteSignal) then
 			abstract[descendant.Name] = networkClient.ClientRemoteSignal.new(descendant)
 			continue
-		elseif descendant:GetAttribute(SharedConstants.attribute.boundToRemoteProperty) then
+		elseif descendant:GetAttribute(sharedEnums.Attribute.boundToRemoteProperty) then
 			abstract[descendant.Name] = networkClient.ClientRemoteProperty.new(descendant)
 			continue
 		end
@@ -62,7 +62,7 @@ local function getNetworkFoldersFromParent(parent: Instance): { Folder }
 	local networkFolders = {}
 
 	for _, networkFolder in parent:GetChildren() do
-		if not networkFolder:GetAttribute(SharedConstants.attribute.networkFolder) then
+		if not networkFolder:GetAttribute(sharedEnums.Attribute.networkFolder) then
 			continue
 		end
 

--- a/src/network/sharedEnums.lua
+++ b/src/network/sharedEnums.lua
@@ -1,5 +1,5 @@
 return table.freeze({
-	attribute = {
+	Attribute = {
 		networkFolder = "IsNetworkFolder",
 		boundToRemoteProperty = "IsBoundToRemoteProperty",
 		boundToRemoteSignal = "IsBoundToRemoteSignal",

--- a/src/network/wally.toml
+++ b/src/network/wally.toml
@@ -3,7 +3,7 @@ name = "bubshayz/network"
 description = "An advanced network module for easy server-client communication."
 authors = ["bubshayz"]
 license = "MIT"
-version = "3.1.0"
+version = "4.0.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
### Added

- Added `RemoteSignal:wait`.

### Changed

- Removed `RemoteSignal:disonnectAll` and `ClientRemoteSignal:disonnectAll`.
- Removed `RemoteSignal:connectOnce` and `ClientRemoteSignal:connectOnce`.
- Fix bug with `ClientRemoteSignal:connect` and `ClientRemoteSignal:wait` not receiving the dispatched events properly in some edge cases.
- `RemoteSignal:connect` and `ClientRemoteSignal:connect` now return an `RBXScriptConnectionObject`. 
- Internal code refactor and improvements.
- Documentation improvements.